### PR TITLE
feat: 全ページに canonical (apex) を追加

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,6 +19,10 @@ const navItems = [
 const current = Astro.url.pathname;
 const isActive = (href: string) =>
   href === '/' ? current === '/' : current.startsWith(href);
+
+// 正規 URL は常に apex (https://skirnir.co.jp) を指す。
+// www やプレビュー (*.pages.dev) で配信された場合のコピーコンテンツ対策。
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!doctype html>
@@ -27,6 +31,7 @@ const isActive = (href: string) =>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
+    <link rel="canonical" href={canonicalURL} />
     <link rel="manifest" href="/manifest.json" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <title>{title}</title>


### PR DESCRIPTION
## 概要

`www.skirnir.co.jp`（および `*.pages.dev` プレビュー）でも同一コンテンツが配信され**コピーコンテンツ**になっているため、正規 URL を apex (`https://skirnir.co.jp`) に固定します。

## 変更内容

- `src/layouts/Layout.astro` の `<head>` に `<link rel="canonical">` を追加
- `Astro.site`（`https://skirnir.co.jp`）+ `Astro.url.pathname` から各ページの正規 URL を生成

## 検証

`pnpm run build` 後の各ページ出力:

| ページ | canonical |
|---|---|
| `/` | `https://skirnir.co.jp/` |
| `/about/` | `https://skirnir.co.jp/about/` |
| `/services/` | `https://skirnir.co.jp/services/` |
| `/contact/` | `https://skirnir.co.jp/contact/` |
| `/tradelaw/` | `https://skirnir.co.jp/tradelaw/` |

## 補足

`www → apex` の 301 リダイレクト自体は Cloudflare 側（terraform リポジトリの Dynamic Redirect ルール）で別途対応します。canonical は belt-and-suspenders（リダイレクトが効かない経路・pages.dev の重複対策）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **SEO改善**
  * 正規URLの設定機能を追加しました。検索エンジンに対して正しいページ情報を伝え、重複コンテンツの問題を防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->